### PR TITLE
CocoaPods could not find compatible versions for pod "GoogleMaps"

### DIFF
--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-DHAVE_GOOGLE_MAPS=1', '-DHAVE_GOOGLE_MAPS_UTILS=1', '-fno-modules'
 
   s.dependency 'React'
-  s.dependency 'GoogleMaps', '3.2.0'
+  s.dependency 'GoogleMaps', '3.1.0'
   s.dependency 'Google-Maps-iOS-Utils', '2.1.0'
 end


### PR DESCRIPTION
[!] CocoaPods could not find compatible versions for pod "GoogleMaps":
  In Podfile:
    GoogleMaps

    react-native-google-maps (from `../node_modules/react-native-maps`) was resolved to 0.26.1, which depends on
      GoogleMaps (= 3.2.0)

Specs satisfying the `GoogleMaps, GoogleMaps (= 3.2.0)` dependency were found, but they required a higher minimum deployment target.